### PR TITLE
adds api call for active agora channels and filters against DB index

### DIFF
--- a/app/Services/AgoraApiService.php
+++ b/app/Services/AgoraApiService.php
@@ -49,6 +49,13 @@ class AgoraApiService
         return $response->getBody()->getContents();
     }
 
+    public function getAllActiveStreams($appId)
+    {
+        $APPID = config('agora.app_id');
+        $response = $this->client->get("dev/v1/channel/$APPID/");
+        return $response->getBody()->getContents();
+    }
+
 //    public function createMediaGateway($userId, $region, $appId)
 //    {
 //        $uuid = Uuid::uuid4()->toString();


### PR DESCRIPTION
Hi! Agora devs here, just trying to help. 

Not very familiar with this stack, just trying to onboard to the project and see if we can contribute in a meaningful way. 

1. This PR addresses [this requirement](https://github.com/ams-ryanolson/agora-laravel-vue/blob/3ad565728979a2344dbc9a7bcbab3aa3ad38c7b8/README.md?plain=1#L48)  by allowing the laravel controller to query Agora for active live channels on Live/index. 
2. Next PR will include a RTM login on the index page that can listen for new live channels being created and update that view without page reload so index page is always showing all channels that are live. 

Would highly recommend adding a DB Cache layer like Redis in future, to reduce QPS on Agora REST services. 

